### PR TITLE
Python 3.9 Support, use Github Workspace path

### DIFF
--- a/action/main.py
+++ b/action/main.py
@@ -6,8 +6,10 @@ import shlex
 import subprocess
 import sys
 from pathlib import Path
+from typing import Union
 
 ACTION_PATH = Path(os.environ["GITHUB_ACTION_PATH"])
+GITHUB_WORKSPACE = Path(os.environ["GITHUB_WORKSPACE"])
 ARGS = os.getenv("INPUT_ARGS", default="")
 SRC = os.getenv("INPUT_SRC", default="")
 
@@ -96,7 +98,7 @@ def read_version_from_pyproject() -> str:
     return version
 
 
-def find_version_in_array(array: object) -> str | None:
+def find_version_in_array(array: object) -> Union[str, None]:
     """Find the version specifier in an array of dependencies."""
     if not isinstance(array, list):
         return None
@@ -185,7 +187,7 @@ proc = subprocess.run(
     ],
     stdout=subprocess.PIPE,
     stderr=subprocess.STDOUT,
-    cwd=ACTION_PATH,
+    cwd=GITHUB_WORKSPACE,
     encoding="utf-8",
     check=False,
 )


### PR DESCRIPTION
str | None syntax is not supported for 3.9 and below.
working directory of ruff should be GITHUB_WORKSPACE instead of GITHUB_ACTION_PATH